### PR TITLE
fix: Resolve remaining CI failures (typer/click, flake8, requests CVE)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 99
+extend-ignore = E203, W503

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         run: isort --check-only src/ tests/
 
       - name: Lint (flake8)
-        run: flake8 src/ tests/
+        run: flake8 --max-line-length=99 --extend-ignore=E203,W503 src/ tests/
 
       - name: Type check (mypy)
         run: mypy --strict src/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,12 @@ dependencies = [
   "pydantic==2.10.5",
   "pydantic-settings==2.7.1",
   "python-dotenv==1.0.1",
-  "requests==2.32.3",
+  "requests==2.32.4",
   "tqdm==4.67.1",
   "joblib==1.4.2",
   "rich==13.9.4",
   "typer==0.15.2",
+  "click>=8.1,<8.2",
 ]
 
 [project.optional-dependencies]

--- a/src/predictive_analytics/__main__.py
+++ b/src/predictive_analytics/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for running predictive_analytics as a module via ``python -m predictive_analytics``."""
+"""Entry point for ``python -m predictive_analytics``."""
 
 from __future__ import annotations
 

--- a/src/predictive_analytics/collection/client.py
+++ b/src/predictive_analytics/collection/client.py
@@ -17,17 +17,15 @@ Typical usage::
 
 from __future__ import annotations
 
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union
 
-import numpy as np
 import pandas as pd
 import requests
 from pydantic import BaseModel, ConfigDict, Field
 
-from predictive_analytics.config.logging import logger, setup_logging
+from predictive_analytics.config.logging import setup_logging
 from predictive_analytics.config.settings import AppConfig
 from predictive_analytics.exceptions import APIRateLimitError, DataCollectionError
 

--- a/src/predictive_analytics/config/settings.py
+++ b/src/predictive_analytics/config/settings.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 from predictive_analytics.exceptions import ConfigurationError
 

--- a/src/predictive_analytics/modeling/forecaster.py
+++ b/src/predictive_analytics/modeling/forecaster.py
@@ -14,7 +14,7 @@ import logging
 import pickle  # nosec B403
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/src/predictive_analytics/modeling/trainer.py
+++ b/src/predictive_analytics/modeling/trainer.py
@@ -14,7 +14,7 @@ import logging
 import pickle  # nosec B403
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/src/predictive_analytics/utils/helpers.py
+++ b/src/predictive_analytics/utils/helpers.py
@@ -17,17 +17,14 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 import random
-import re
 import string
 import time
 from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
-import numpy as np
 import pandas as pd
 
 from predictive_analytics.config.logging import setup_logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-import matplotlib
-import numpy as np
-import pandas as pd
-import pytest
-from pydantic import SecretStr
+import matplotlib  # noqa: E402
 
 matplotlib.use("Agg")
 
-from predictive_analytics.config.settings import APIConfig, AppConfig, ModelConfig
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+from pydantic import SecretStr  # noqa: E402
+
+from predictive_analytics.config.settings import APIConfig, AppConfig, ModelConfig  # noqa: E402
 
 
 @pytest.fixture()

--- a/tests/unit/analysis/test_explorer.py
+++ b/tests/unit/analysis/test_explorer.py
@@ -14,7 +14,7 @@ Covers every public method of :class:`TimeSeriesExplorer`, the standalone
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -369,9 +369,7 @@ class TestPlotLagScatter:
 class TestRunFullAnalysis:
     """Tests for :meth:`TimeSeriesExplorer.run_full_analysis`."""
 
-    def test_interactive_mode(
-        self, explorer: TimeSeriesExplorer, mocker: "pytest_mock.MockerFixture"
-    ) -> None:
+    def test_interactive_mode(self, explorer: TimeSeriesExplorer, mocker: MagicMock) -> None:
         """When no output_dir is given, plots are shown interactively."""
         mocker.patch.object(explorer, "plot_time_series")
         mocker.patch.object(explorer, "plot_seasonal_decomposition")
@@ -399,7 +397,7 @@ class TestRunFullAnalysis:
         self,
         explorer: TimeSeriesExplorer,
         tmp_path: Path,
-        mocker: "pytest_mock.MockerFixture",
+        mocker: MagicMock,
     ) -> None:
         """When output_dir is given, plt.savefig and plt.close are called."""
         mocker.patch.object(explorer, "plot_time_series")

--- a/tests/unit/collection/test_client.py
+++ b/tests/unit/collection/test_client.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest

--- a/tests/unit/collection/test_preprocessing.py
+++ b/tests/unit/collection/test_preprocessing.py
@@ -10,7 +10,6 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import numpy as np

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -10,7 +10,6 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/modeling/test_forecaster.py
+++ b/tests/unit/modeling/test_forecaster.py
@@ -23,7 +23,7 @@ ExponentialSmoothing) are mocked.
 from __future__ import annotations
 
 import pickle
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch

--- a/tests/unit/modeling/test_trainer.py
+++ b/tests/unit/modeling/test_trainer.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pickle
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np

--- a/tests/unit/utils/test_helpers.py
+++ b/tests/unit/utils/test_helpers.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import numpy as np
 import pandas as pd
 import pytest
 


### PR DESCRIPTION
## Summary

- **Tests**: Pin `click>=8.1,<8.2` to prevent `Parameter.make_metavar()` signature incompatibility between typer 0.15.2 and click 8.2+. Fixes the 2 `--help` test failures.
- **Lint**: Add `.flake8` config file (flake8 doesn't read `[tool.flake8]` from `pyproject.toml`). Pass `--max-line-length=99 --extend-ignore=E203,W503` in the lint workflow. Remove all unused imports (F401) and fix undefined names (F821) across 11 files.
- **Security**: Bump `requests` 2.32.3 -> 2.32.4 (GHSA-9hjg-9r4m-mvj7).

## Test plan

- [x] 474 tests passing, 100% coverage
- [x] `black --check` clean (42 files)
- [x] `isort --check-only` clean
- [x] `flake8 --max-line-length=99` reports 0 issues
- [x] `bandit -r src/` reports 0 issues
- [ ] All 3 GitHub Actions workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)